### PR TITLE
Rdb naa

### DIFF
--- a/Code/helpers/naa_helpers.R
+++ b/Code/helpers/naa_helpers.R
@@ -1,0 +1,51 @@
+########################################################
+########################################################
+# Some helper functions that are used by both by Rdb_convert_and_push_NAA_to_gdrive
+# borrowed from the groundfishRDM repo
+
+########################################################
+#
+# From the dashboard repo, this wrestles the wide NAA data into long format.
+#
+########################################################
+pivot_naa_long <- function(df) {
+  age_cols <- grep("^age\\d+$", names(df), value = TRUE)
+  df %>%
+    tidyr::pivot_longer(cols = all_of(age_cols),
+                        names_to  = "age",
+                        values_to = "value") %>%
+    mutate(age = as.integer(sub("age", "", age)),
+           metric=glue("{metric} {age}")) %>%
+    select(-age)
+}
+
+
+########################################################
+# Define the validation function
+# Is our data what it claims to be.  We should have some characters, some
+# numerics, a date. These should have no missing values.
+########################################################
+validate_naa_data <- function(df) {
+
+  # Ensure specified columns are character vectors and contain no NAs
+  stopifnot(
+    is.character(df$fishery) && !any(is.na(df$fishery)),
+    is.character(df$common) && !any(is.na(df$common)),
+    is.character(df$stock_abbrev) && !any(is.na(df$stock_abbrev)),
+    is.character(df$metric) && !any(is.na(df$metric)),
+    is.character(df$source) && !any(is.na(df$source)),
+    is.character(df$units) && !any(is.na(df$units))
+  )
+
+  # Ensure species_itis and value are numeric
+  stopifnot(is.numeric(df$species_itis))
+  stopifnot(is.numeric(df$value))
+
+  # Ensure data_version is a Date class
+  stopifnot(inherits(df$data_version, "Date"))
+
+  # NOTE: state and wave are allowed to be NA; no type enforcement applied here
+
+  # Return the dataframe invisibly to support tidyverse piping (%>%)
+  invisible(df)
+}

--- a/Code/helpers/naa_helpers.R
+++ b/Code/helpers/naa_helpers.R
@@ -25,7 +25,7 @@ pivot_naa_long <- function(df) {
 # Is our data what it claims to be.  We should have some characters, some
 # numerics, a date. These should have no missing values.
 ########################################################
-validate_naa_data <- function(df) {
+validate_naa_data <- function(df, file_in, age_classes, projected_names, historical_names, ndraws=NULL) {
 
   # Ensure specified columns are character vectors and contain no NAs
   stopifnot(
@@ -44,6 +44,23 @@ validate_naa_data <- function(df) {
   # Ensure data_version is a Date class
   stopifnot(inherits(df$data_version, "Date"))
 
+  
+  
+  # Historical data should have the same number of rows as age classes.
+  if (file_in %in% projected_names){
+    stopifnot(nrow(df) != age_classes)
+  } 
+  
+  
+  
+  # Projection data should have classes * draws
+  if (file_in %in% historical_names){
+    stopifnot(nrow(df) != age_classes * ndraws)
+    } 
+    
+  
+  
+  
   # NOTE: state and wave are allowed to be NA; no type enforcement applied here
 
   # Return the dataframe invisibly to support tidyverse piping (%>%)

--- a/Code/helpers/naa_helpers.R
+++ b/Code/helpers/naa_helpers.R
@@ -25,8 +25,8 @@ pivot_naa_long <- function(df) {
 # Is our data what it claims to be.  We should have some characters, some
 # numerics, a date. These should have no missing values.
 ########################################################
-validate_naa_data <- function(df, file_in, age_classes, projected_names, historical_names, ndraws=NULL) {
-
+validate_naa_data <- function(df, file_in, type, age_classes, ndraws=NULL) {
+  
   # Ensure specified columns are character vectors and contain no NAs
   stopifnot(
     is.character(df$fishery) && !any(is.na(df$fishery)),
@@ -47,15 +47,13 @@ validate_naa_data <- function(df, file_in, age_classes, projected_names, histori
   
   
   # Historical data should have the same number of rows as age classes.
-  if (file_in %in% projected_names){
-    stopifnot(nrow(df) != age_classes)
+  if (type == "historical"){
+    stopifnot(nrow(df) == age_classes)
   } 
   
-  
-  
-  # Projection data should have classes * draws
-  if (file_in %in% historical_names){
-    stopifnot(nrow(df) != age_classes * ndraws)
+    # Projection data should have classes * draws
+  if (type == "projected"){
+    stopifnot(nrow(df) == age_classes * ndraws)
     } 
     
   

--- a/Code/pre_sim/get_assessment_from_gdrive.do
+++ b/Code/pre_sim/get_assessment_from_gdrive.do
@@ -29,7 +29,6 @@ foreach s of local filestubs {
 local file_list : dir "`google_folder'" files "*"
 
 local i=0
-local j=0
 foreach file of local file_list {
     copy "`google_folder'/`file'" "${misc_data_cd}/`file'", replace
 	local ++i

--- a/Code/pre_sim/get_assessment_from_gdrive.do
+++ b/Code/pre_sim/get_assessment_from_gdrive.do
@@ -28,6 +28,12 @@ foreach s of local filestubs {
 
 local file_list : dir "`google_folder'" files "*"
 
+local i=0
+local j=0
 foreach file of local file_list {
     copy "`google_folder'/`file'" "${misc_data_cd}/`file'", replace
+	local ++i
+
 }
+
+di "`i' assessment and projection files copied"

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -151,8 +151,6 @@ loc catch_per_trip1 = 1				// Part 1 of catch per trip
 loc copula_in_R = 1					// Copula model in R
 loc catch_per_trip2 = 1				// Part 2 of catch per trip
 loc compare_calibration_MRIP = 1	// compare calibration output to MRIP
-loc prep_NAA_for_dashboard = 1		// Pull Assessment data
-loc push_NAA_to_gdrive =1 			// Convert Assessment data to Rds, reshape to long, and push to googledrive
 loc prep_cpt_for_dashboard= 0		// prep data for dashboard NOT IN WRAPPER. NOT WRITTEN, See Groundfish repo
 loc Rpush_to_gdrive =0 				// Push to google drive in R NOT IN WRAPPER. WRITTEN but not tested 
 loc angler_demogs	=1				// add additonal angler demographics
@@ -160,6 +158,8 @@ loc generate_baseline=1				// Generate baseline-year catch-at-length
 loc catch_at_length_project=1		// Generate projection-year catch-at-length
 loc catch_per_trip_project=1       // Generate projection-year catch-per trip
 
+loc prep_NAA_for_dashboard = 1		// Pull Assessment data
+loc push_NAA_to_gdrive =1 			// Convert Assessment data to Rds, reshape to long, and push to googledrive
 
 
 // Prototyping

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -151,7 +151,8 @@ loc catch_per_trip1 = 1				// Part 1 of catch per trip
 loc copula_in_R = 1					// Copula model in R
 loc catch_per_trip2 = 1				// Part 2 of catch per trip
 loc compare_calibration_MRIP = 1	// compare calibration output to MRIP
-loc prep_NAA_for_dashboard = 1		 		// Pull Assessment data
+loc prep_NAA_for_dashboard = 1		// Pull Assessment data
+loc push_NAA_to_gdrive =1 			// Convert Assessment data to Rds, reshape to long, and push to googledrive
 loc prep_cpt_for_dashboard= 0		// prep data for dashboard NOT IN WRAPPER. NOT WRITTEN, See Groundfish repo
 loc Rpush_to_gdrive =0 				// Push to google drive in R NOT IN WRAPPER. WRITTEN but not tested 
 loc angler_demogs	=1				// add additonal angler demographics
@@ -162,7 +163,7 @@ loc catch_per_trip_project=1       // Generate projection-year catch-per trip
 
 
 // Prototyping
-local proto = 1
+local proto = 0
 
 if `proto' {
 	global ndraws 3
@@ -182,6 +183,13 @@ if `pull_assessment' {
 if `prep_NAA_for_dashboard' {
 	di "Pulling Assessment data from google"
 	do "$input_code_cd\rdb_processing_NAA.do"
+	}
+if `push_NAA_to_gdrive' {
+	di "Converting dta to Rds and pushing to GDrive"
+	
+			rscript using "$input_code_cd\rdb_convert_and_push_NAA_to_gdrive.R"
+	di "NAA pushed to GDrive"
+
 	}
 
 	

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -151,6 +151,7 @@ loc catch_per_trip1 = 1				// Part 1 of catch per trip
 loc copula_in_R = 1					// Copula model in R
 loc catch_per_trip2 = 1				// Part 2 of catch per trip
 loc compare_calibration_MRIP = 1	// compare calibration output to MRIP
+loc prep_NAA_for_dashboard = 1		 		// Pull Assessment data
 loc prep_cpt_for_dashboard= 0		// prep data for dashboard NOT IN WRAPPER. NOT WRITTEN, See Groundfish repo
 loc Rpush_to_gdrive =0 				// Push to google drive in R NOT IN WRAPPER. WRITTEN but not tested 
 loc angler_demogs	=1				// add additonal angler demographics
@@ -177,6 +178,13 @@ if `pull_assessment' {
 	do "$input_code_cd\get_assessment_from_gdrive.do"
 	}
 
+	/* This code requires you to mount your google drive to D on your computer */
+if `prep_NAA_for_dashboard' {
+	di "Pulling Assessment data from google"
+	do "$input_code_cd\rdb_processing_NAA.do"
+	}
+
+	
 	
 
 // 1) Pull the MRIP data

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -186,8 +186,9 @@ if `prep_NAA_for_dashboard' {
 	}
 if `push_NAA_to_gdrive' {
 	di "Converting dta to Rds and pushing to GDrive"
-	
-			rscript using "$input_code_cd\rdb_convert_and_push_NAA_to_gdrive.R"
+     /* push through the ndraws into R, so we can make sure we have the proper number of rows */	
+	rscript using "$input_code_cd\rdb_convert_and_push_NAA_to_gdrive.R" , args($ndraws) 
+
 	di "NAA pushed to GDrive"
 
 	}

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -104,7 +104,7 @@ global NEFSC_svy_yrs "inlist(year,2024, 2023, 2022)"
 global inflation_expansion=1.31 
 
 /* find the root of the project 
-prior to running the wrapper, you must change to $groundfishRDMdir so here picks up the project
+prior to running the wrapper, you must change to the $flukeRDMdir so here picks up the project
 */
 
 here, nogit 

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -45,7 +45,7 @@ filestubs<-c("SummerFlounder_historicalNAA",
                         "BlackSeaBassSouth_projectedNAA",
                         "BlackSeaBassSouth_projectedNAA"
 )
-
+NAA_long_holder<-list()
 
 #I'm writing a loop instead of an lapply. Sorry.
 for (file_in in filestubs){
@@ -67,8 +67,9 @@ for (file_in in filestubs){
   validate_naa_data(NAA_long)
   # Save dataframe as Rds
   write_rds(NAA_long, file=output_file_and_path)
-  
   message(file_in, " saved as .Rds")
+  
+  NAA_long_holder[[file_in]]<-NAA_long
   }
   
   

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -1,0 +1,107 @@
+#This code reads in a catch per trip dta for the rec dashboard and uploads it to Google drive as an Rds
+
+
+#Load libraries
+library(tidyverse)
+library(haven)
+library(glue)
+library(googledrive)
+library(here)
+
+here::i_am("Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R")
+source(here("Code", "helpers", "developer_setup.R"))
+source(here("Code","helpers","naa_helpers.R"))
+
+misc_data_dir<-file.path(sf.data.dir, "miscellaneous")
+
+# Find the most recent files. Assume that all 6 age structures are read on the same day.
+
+file_pattern<-"SummerFlounder_projectedNAA_"
+data_vintage_string<-list.files(misc_data_dir, pattern=glob2rx(glue("{file_pattern}*.dta")))
+data_vintage_string<-gsub(file_pattern,"",data_vintage_string)
+data_vintage_string<-gsub(".dta","",data_vintage_string)
+data_vintage_string<-max(data_vintage_string)
+
+
+filestubs_projected<-c("SummerFlounder_projectedNAA",
+                        "Scup_projectedNAA",
+                        "BlackSeaBassSouth_projectedNAA",
+                        "BlackSeaBassSouth_projectedNAA"
+)
+
+
+filestubs_historical<-c("SummerFlounder_historicalNAA",
+             "Scup_historicalNAA",
+             "BlackSeaBassSouth_historicalNAA",
+             "BlackSeaBassSouth_historicalNAA"
+)
+
+filestubs<-c("SummerFlounder_historicalNAA",
+                        "Scup_historicalNAA",
+                        "BlackSeaBassSouth_historicalNAA",
+                        "BlackSeaBassSouth_historicalNAA",
+                        "SummerFlounder_projectedNAA",
+                        "Scup_projectedNAA",
+                        "BlackSeaBassSouth_projectedNAA",
+                        "BlackSeaBassSouth_projectedNAA"
+)
+
+
+#I'm writing a loop instead of an lapply. Sorry.
+for (file_in in filestubs){
+
+  input_file_and_path <- file.path(misc_data_dir,glue("{file_in}_{data_vintage_string}.dta"))
+  
+  output_file<-glue("{file_in}_{data_vintage_string}.Rds")
+  output_file_and_path<- file.path(misc_data_dir,output_file)
+  
+  # Read in my .dta file
+  working_NAA <- read_dta(input_file_and_path)
+  working_NAA <- working_NAA  %>%
+    zap_formats() %>%
+    zap_label() %>%
+    mutate(data_version=ymd(data_version)) %>%
+    relocate(year, fishery, common, species_itis,stock_abbrev, state, wave, metric,units, source, data_version)
+  NAA_long<-pivot_naa_long(working_NAA)
+
+  validate_naa_data(NAA_long)
+  # Save dataframe as Rds
+  write_rds(NAA_long, file=output_file_and_path)
+  
+  message(file_in, " saved as .Rds")
+  }
+  
+  
+  
+  # Connect to Google Drive
+  # NOTE: Relies on cached credentials in .secrets. Will prompt interactive auth if missing or expired.
+  drive_auth(cache = here(".secrets"), email = TRUE)
+  
+  # Output folder on google drive
+  miscellaneous_path <-file.path("socialsci","RecreationalDST","2028_management_cycle_data",
+                                 "flukeRDM","miscellaneous")
+  # Get the id of that folder.
+  folder_info <- drive_get(
+    path = miscellaneous_path,
+    shared_drive = "NMFS NEC READ SSB"
+  )
+  miscellaneous_path<-folder_info$id
+  
+  
+  
+# push the NAA to google drive  
+for (file_in in filestubs){
+    
+    output_file<-glue("{file_in}_{data_vintage_string}.Rds")
+    output_file_and_path<- file.path(misc_data_dir,output_file)
+    
+  #Put the catch per trip Rds on google drive
+  drive_upload(
+    media = file.path(output_file_and_path),
+    path = as_id(miscellaneous_path),
+    name = output_file,
+    overwrite = TRUE
+  )
+  message(output_file, " Written to GoogleDrive")
+  
+}

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -23,20 +23,20 @@ data_vintage_string<-gsub(".dta","",data_vintage_string)
 data_vintage_string<-max(data_vintage_string)
 
 
-filestubs_projected<-c("SummerFlounder_projectedNAA",
+SFSBSB_filestubs_projected<-c("SummerFlounder_projectedNAA",
                         "Scup_projectedNAA",
                         "BlackSeaBassSouth_projectedNAA",
                         "BlackSeaBassNorth_projectedNAA"
 )
 
 
-filestubs_historical<-c("SummerFlounder_historicalNAA",
+SFSBSB_filestubs_historical<-c("SummerFlounder_historicalNAA",
              "Scup_historicalNAA",
              "BlackSeaBassSouth_historicalNAA",
              "BlackSeaBassNorth_historicalNAA"
 )
 
-filestubs<-c("SummerFlounder_historicalNAA",
+SFSBSB_filestubs<-c("SummerFlounder_historicalNAA",
                         "Scup_historicalNAA",
                         "BlackSeaBassSouth_historicalNAA",
                         "BlackSeaBassNorth_historicalNAA",
@@ -48,7 +48,7 @@ filestubs<-c("SummerFlounder_historicalNAA",
 NAA_long_holder<-list()
 
 #I'm writing a loop instead of an lapply. Sorry.
-for (file_in in filestubs){
+for (file_in in SFSBSB_filestubs){
 
   input_file_and_path <- file.path(misc_data_dir,glue("{file_in}_{data_vintage_string}.dta"))
   

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -73,7 +73,7 @@ for (file_in in SFSBSB_filestubs){
   }
   
 # Ensure we have the right number of files
-stopifnot(length(NAA_long_holder)==length(filestubs))  
+stopifnot(length(NAA_long_holder)==length(SFSBSB_filestubs))  
   
   # Connect to Google Drive
   # NOTE: Relies on cached credentials in .secrets. Will prompt interactive auth if missing or expired.
@@ -94,7 +94,7 @@ stopifnot(length(NAA_long_holder)==length(filestubs))
   
   
 # push the NAA to google drive  
-for (file_in in filestubs){
+for (file_in in SFSBSB_filestubs){
     
     output_file<-glue("{file_in}_{data_vintage_string}.Rds")
     output_file_and_path<- file.path(misc_data_dir,output_file)

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -26,24 +26,24 @@ data_vintage_string<-max(data_vintage_string)
 filestubs_projected<-c("SummerFlounder_projectedNAA",
                         "Scup_projectedNAA",
                         "BlackSeaBassSouth_projectedNAA",
-                        "BlackSeaBassSouth_projectedNAA"
+                        "BlackSeaBassNorth_projectedNAA"
 )
 
 
 filestubs_historical<-c("SummerFlounder_historicalNAA",
              "Scup_historicalNAA",
              "BlackSeaBassSouth_historicalNAA",
-             "BlackSeaBassSouth_historicalNAA"
+             "BlackSeaBassNorth_historicalNAA"
 )
 
 filestubs<-c("SummerFlounder_historicalNAA",
                         "Scup_historicalNAA",
                         "BlackSeaBassSouth_historicalNAA",
-                        "BlackSeaBassSouth_historicalNAA",
+                        "BlackSeaBassNorth_historicalNAA",
                         "SummerFlounder_projectedNAA",
                         "Scup_projectedNAA",
                         "BlackSeaBassSouth_projectedNAA",
-                        "BlackSeaBassSouth_projectedNAA"
+                        "BlackSeaBassNorth_projectedNAA"
 )
 NAA_long_holder<-list()
 
@@ -72,7 +72,8 @@ for (file_in in filestubs){
   NAA_long_holder[[file_in]]<-NAA_long
   }
   
-  
+# Ensure we have the right number of files
+stopifnot(length(NAA_long_holder)==length(filestubs))  
   
   # Connect to Google Drive
   # NOTE: Relies on cached credentials in .secrets. Will prompt interactive auth if missing or expired.
@@ -81,6 +82,8 @@ for (file_in in filestubs){
   # Output folder on google drive
   miscellaneous_path <-file.path("socialsci","RecreationalDST","2028_management_cycle_data",
                                  "flukeRDM","miscellaneous")
+  
+  message("Searching for file path")
   # Get the id of that folder.
   folder_info <- drive_get(
     path = miscellaneous_path,

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -11,7 +11,6 @@ if (length(args) != 1) {
 number_of_draws  <- as.numeric(args[1])
 # Show them, just in case.
 cat("Number of Draws (should match ndraws global from stata:", number_of_draws, "\n")
-
 #Load libraries
 library(tidyverse)
 library(haven)
@@ -61,6 +60,11 @@ NAA_long_holder<-list()
 #I'm writing a loop instead of an lapply. Sorry.
 for (file_in in SFSBSB_filestubs){
 
+  if (file_in %in% SFSBSB_filestubs_historical){
+    type<-"historical"
+  } else  if (file_in %in% SFSBSB_filestubs_projected){
+    type<-"projected"
+  }
   input_file_and_path <- file.path(misc_data_dir,glue("{file_in}_{data_vintage_string}.dta"))
   
   output_file<-glue("{file_in}_{data_vintage_string}.Rds")
@@ -86,9 +90,7 @@ for (file_in in SFSBSB_filestubs){
   
   validate_naa_data(df=NAA_long,
                     age_classes=age_classes,
-                    file_in=file_in,
-                    projected_names=SFSBSB_filestubs_projected,
-                    historical_names=SFSBSB_filestubs_historical, 
+                    type=type,
                     ndraws=number_of_draws)
     
   # Save dataframe as Rds

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -1,6 +1,18 @@
 #This code reads in a catch per trip dta for the rec dashboard and uploads it to Google drive as an Rds
 
 
+# Define arguments
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1) {
+  stop("Error: This script requires exactly one argument.", call. = FALSE)
+}
+
+#read in arguments. Ensure they are numeric
+number_of_draws  <- as.numeric(args[1])
+# Show them, just in case.
+cat("Number of Draws (should match ndraws global from stata:", number_of_draws, "\n")
+
+
 #Load libraries
 library(tidyverse)
 library(haven)
@@ -57,13 +69,24 @@ for (file_in in SFSBSB_filestubs){
   
   # Read in my .dta file
   working_NAA <- read_dta(input_file_and_path)
+  # Strip formats, labels, and add the data_versionfield.
   working_NAA <- working_NAA  %>%
     zap_formats() %>%
     zap_label() %>%
     mutate(data_version=ymd(data_version)) %>%
     relocate(year, fishery, common, species_itis,stock_abbrev, state, wave, metric,units, source, data_version)
+  
+  age_classes<-working_NAA%>% 
+         select(starts_with("age")) %>% 
+         ncol()
+  
+  
+  # make it long
   NAA_long<-pivot_naa_long(working_NAA)
-
+  #make sure I have the proper number of rows. Throw an informative error message if not.
+  if (nrow(NAA_long) != age_classes * number_of_draws) {
+    stop(glue("Error in file {file_in}"))
+  }  
   validate_naa_data(NAA_long)
   # Save dataframe as Rds
   write_rds(NAA_long, file=output_file_and_path)

--- a/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
+++ b/Code/pre_sim/rdb_convert_and_push_NAA_to_gdrive.R
@@ -12,7 +12,6 @@ number_of_draws  <- as.numeric(args[1])
 # Show them, just in case.
 cat("Number of Draws (should match ndraws global from stata:", number_of_draws, "\n")
 
-
 #Load libraries
 library(tidyverse)
 library(haven)
@@ -76,18 +75,22 @@ for (file_in in SFSBSB_filestubs){
     mutate(data_version=ymd(data_version)) %>%
     relocate(year, fishery, common, species_itis,stock_abbrev, state, wave, metric,units, source, data_version)
   
-  age_classes<-working_NAA%>% 
-         select(starts_with("age")) %>% 
-         ncol()
+  age_classes<-working_NAA%>%
+    select(starts_with("age")) %>%
+    ncol()
   
   
   # make it long
   NAA_long<-pivot_naa_long(working_NAA)
   #make sure I have the proper number of rows. Throw an informative error message if not.
-  if (nrow(NAA_long) != age_classes * number_of_draws) {
-    stop(glue("Error in file {file_in}"))
-  }  
-  validate_naa_data(NAA_long)
+  
+  validate_naa_data(df=NAA_long,
+                    age_classes=age_classes,
+                    file_in=file_in,
+                    projected_names=SFSBSB_filestubs_projected,
+                    historical_names=SFSBSB_filestubs_historical, 
+                    ndraws=number_of_draws)
+    
   # Save dataframe as Rds
   write_rds(NAA_long, file=output_file_and_path)
   message(file_in, " saved as .Rds")

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -44,17 +44,18 @@ set seed 12345
 /* Process stock assessment */
 * Notes: 
 	*summer flounder and scup NAA data include age0-age7
-	*black sea bass NAA data include age1-age8 and are in 1000s
-	*terminal year estimates are in 1,000s of fish for all species
+	*black sea bass NAA data include age1-age8 
+* Units 
+	* summer Flounder historical - 1,000s
+	* summer flounder projected individuals  terminal year estimates are in 1,000s of fish for all species
 
-* We push everything to the dashboard in units of thousands, so we need to scale SF and Scup historical
+* We push everything to the dashboard in units of thousands, so we need to scale SF projections, 
 	
 /* Summer flounder */
 import delimited using "$misc_data_cd/`sf_assess'", clear
 
 
 forvalues class =0/7{
-	replace a`class'=`class'/1000
 	rename a`class' age`class'
 
 }
@@ -77,12 +78,12 @@ sample $ndraws, count
 capture drop draw
 save "$misc_data_cd/`SF_historical_filename'", replace
 
-
+/* sf projections are in individuals, so divide by 1000 */
 import delimited using "$misc_data_cd/`sf_project'", clear
 
 forvalues class =0/7{
-	replace a`class'=`class'
 	rename a`class' age`class'
+	replace age`class'=age`class'/1000
 
 }
 
@@ -112,8 +113,8 @@ import delimited using "$misc_data_cd/`scup_assess'", clear
 
 
 forvalues class =0/7{
-	replace a`class'=`class'/100
 	rename a`class' age`class'
+
 
 }
 
@@ -136,11 +137,11 @@ capture drop draw
 
 save "$misc_data_cd/`Scup_historical_filename'", replace
 
-
+/* scup projections are in individuals, so divide by 1000 */
 import delimited using "$misc_data_cd/`scup_project'", clear
 
 forvalues class =0/7{
-	replace a`class'=`class'
+	replace a`class'=`class'/1000
 	rename a`class' age`class'
 
 }

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -35,13 +35,20 @@ local Scup_historical_filename "Scup_historicalNAA_`vintage_string'.dta"
 local BSB_South_projected_filename "BlackSeaBassSouth_projectedNAA_`vintage_string'.dta"
 local BSB_South_historical_filename "BlackSeaBassSouth_historicalNAA_`vintage_string'.dta"
 
-local BSB_North_projected_filename "BlackSeaBassSouth_projectedNAA_`vintage_string'.dta"
-local BSB_North_historical_filename "BlackSeaBassSouth_historicalNAA_`vintage_string'.dta"
+local BSB_North_projected_filename "BlackSeaBassNorth_projectedNAA_`vintage_string'.dta"
+local BSB_North_historical_filename "BlackSeaBassNorth_historicalNAA_`vintage_string'.dta"
 
 
 set seed 12345
 
 /* Process stock assessment */
+* Notes: 
+	*summer flounder and scup NAA data include age0-age7
+	*black sea bass NAA data include age1-age8 and are in 1000s
+	*terminal year estimates are in 1,000s of fish for all species
+
+* We push everything to the dashboard in units of thousands, so we need to scale SF and Scup historical
+	
 /* Summer flounder */
 import delimited using "$misc_data_cd/`sf_assess'", clear
 
@@ -74,7 +81,7 @@ save "$misc_data_cd/`SF_historical_filename'", replace
 import delimited using "$misc_data_cd/`sf_project'", clear
 
 forvalues class =0/7{
-	replace a`class'=`class'/1000
+	replace a`class'=`class'
 	rename a`class' age`class'
 
 }
@@ -105,7 +112,7 @@ import delimited using "$misc_data_cd/`scup_assess'", clear
 
 
 forvalues class =0/7{
-	replace a`class'=`class'/1000
+	replace a`class'=`class'/100
 	rename a`class' age`class'
 
 }
@@ -133,7 +140,7 @@ save "$misc_data_cd/`Scup_historical_filename'", replace
 import delimited using "$misc_data_cd/`scup_project'", clear
 
 forvalues class =0/7{
-	replace a`class'=`class'/1000
+	replace a`class'=`class'
 	rename a`class' age`class'
 
 }

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -240,7 +240,7 @@ gen fishery= "SFSBSB"
 gen common= "BLACK SEA BASS"
 gen state=""
 gen wave=.
-gen metric="2024 Numbers at Age"
+gen metric="2026 Numbers at Age"
 gen source = "2024 Assessment"
 gen stock_abbrev = "SOUTH"
 gen species_itis =167687
@@ -249,6 +249,7 @@ gen str data_version= "`vintage_string'"
 
 duplicates drop 
 capture drop year
+gen year=2026
 sample $ndraws, count
 capture drop draw
 

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -46,8 +46,10 @@ set seed 12345
 import delimited using "$misc_data_cd/`sf_assess'", clear
 
 
-foreach var of varlist a0-a7{
-	replace `var'=`var'/1000
+forvalues class =0/7{
+	replace a`class'=`class'/1000
+	rename a`class' age`class'
+
 }
 
 gen fishery= "SFSBSB"
@@ -64,16 +66,17 @@ gen str data_version= "`vintage_string'"
 
 duplicates drop 
 assert year==2024
-drop year
 sample $ndraws, count
-
+capture drop draw
 save "$misc_data_cd/`SF_historical_filename'", replace
 
 
 import delimited using "$misc_data_cd/`sf_project'", clear
 
-foreach var of varlist a0-a7{
-	replace `var'=`var'/1000
+forvalues class =0/7{
+	replace a`class'=`class'/1000
+	rename a`class' age`class'
+
 }
 
 gen fishery= "SFSBSB"
@@ -91,7 +94,6 @@ gen str data_version= "`vintage_string'"
 duplicates drop 
 assert year==2026
 
-drop year
 sample $ndraws, count
 
 save "$misc_data_cd/`SF_projected_filename'", replace
@@ -102,8 +104,10 @@ save "$misc_data_cd/`SF_projected_filename'", replace
 import delimited using "$misc_data_cd/`scup_assess'", clear
 
 
-foreach var of varlist a0-a7{
-	replace `var'=`var'/1000
+forvalues class =0/7{
+	replace a`class'=`class'/1000
+	rename a`class' age`class'
+
 }
 
 gen fishery= "SFSBSB"
@@ -120,16 +124,18 @@ gen str data_version= "`vintage_string'"
 
 duplicates drop 
 assert year==2024
-drop year
 sample $ndraws, count
+capture drop draw
 
 save "$misc_data_cd/`Scup_historical_filename'", replace
 
 
 import delimited using "$misc_data_cd/`scup_project'", clear
 
-foreach var of varlist a0-a7{
-	replace `var'=`var'/1000
+forvalues class =0/7{
+	replace a`class'=`class'/1000
+	rename a`class' age`class'
+
 }
 
 gen fishery= "SFSBSB"
@@ -146,7 +152,6 @@ gen str data_version= "`vintage_string'"
 
 duplicates drop
 assert year==2026 
-drop year
 sample $ndraws, count
 
 save "$misc_data_cd/`Scup_projected_filename'", replace
@@ -159,8 +164,8 @@ save "$misc_data_cd/`Scup_projected_filename'", replace
 /*******************************************************/
 import delimited using "$misc_data_cd/`bsb_assessS'", clear
 
-forv i = 1/8 {
-    rename v`i' a`i'    
+forvalues i = 1/8 {
+    rename v`i' age`i'    
 }
 
 
@@ -170,23 +175,24 @@ gen state=""
 gen wave=.
 gen metric="2024 Numbers at Age"
 gen source = "2024 Assessment"
-gen stock_abbrev = ""
+gen stock_abbrev = "SOUTH"
 gen species_itis =167687
 gen units = "Thousands"
-gen region  = "SOUTH"
 gen str data_version= "`vintage_string'"
 
 duplicates drop 
 capture drop year
+gen year=2024
 sample $ndraws, count
+capture drop draw
 
 save "$misc_data_cd/`BSB_South_historical_filename'", replace
 
 
 import delimited using "$misc_data_cd/`bsb_assessN'", clear
 
-forv i = 1/8 {
-    rename v`i' a`i'    
+forvalues i = 1/8 {
+    rename v`i' age`i'    
 }
 
 
@@ -196,15 +202,16 @@ gen state=""
 gen wave=.
 gen metric="2024 Numbers at Age"
 gen source = "2024 Assessment"
-gen stock_abbrev = ""
+gen stock_abbrev = "NORTH"
 gen species_itis =167687
 gen units = "Thousands"
-gen region  = "NORTH"
 gen str data_version= "`vintage_string'"
 
 duplicates drop 
 capture drop year
+gen year=2024
 sample $ndraws, count
+capture drop draw
 
 save "$misc_data_cd/`BSB_North_historical_filename'", replace
 
@@ -217,8 +224,8 @@ save "$misc_data_cd/`BSB_North_historical_filename'", replace
 
 import delimited using "$misc_data_cd/`bsb_projectS'", clear
 
-forv i = 1/8 {
-    rename v`i' a`i'    
+forvalues i = 1/8 {
+    rename v`i' age`i'    
 }
 
 
@@ -228,23 +235,23 @@ gen state=""
 gen wave=.
 gen metric="2024 Numbers at Age"
 gen source = "2024 Assessment"
-gen stock_abbrev = ""
+gen stock_abbrev = "SOUTH"
 gen species_itis =167687
 gen units = "Thousands"
-gen region  = "SOUTH"
 gen str data_version= "`vintage_string'"
 
 duplicates drop 
 capture drop year
 sample $ndraws, count
+capture drop draw
 
 save "$misc_data_cd/`BSB_South_projected_filename'", replace
 
 
 import delimited using "$misc_data_cd/`bsb_projectN'", clear
 
-forv i = 1/8 {
-    rename v`i' a`i'    
+forvalues i = 1/8 {
+    rename v`i' age`i'    
 }
 
 
@@ -254,14 +261,15 @@ gen state=""
 gen wave=.
 gen metric="2026 Numbers at Age"
 gen source = "2024 Assessment"
-gen stock_abbrev = ""
+gen stock_abbrev = "NORTH"
 gen species_itis =167687
 gen units = "Thousands"
-gen region  = "NORTH"
 gen str data_version= "`vintage_string'"
 
 duplicates drop 
 capture drop year
+gen year=2026
 sample $ndraws, count
+capture drop draw
 
 save "$misc_data_cd/`BSB_North_projected_filename'", replace

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -59,13 +59,15 @@ forvalues class =0/7{
 	rename a`class' age`class'
 
 }
+collapse (mean) age*, by(year)
+
 
 gen fishery= "SFSBSB"
 gen common= "SUMMER FLOUNDER"
 gen state=""
 gen wave=.
 gen metric="2024 Numbers at Age"
-gen source = "2024 Assessment"
+gen source = "2025 Assessment"
 gen stock_abbrev = ""
 gen species_itis =172735
 gen units = "Thousands"
@@ -92,7 +94,7 @@ gen common= "SUMMER FLOUNDER"
 gen state=""
 gen wave=.
 gen metric="2026 Projected Numbers At Age"
-gen source = "2024 Assessment"
+gen source = "2025 Assessment"
 gen stock_abbrev = ""
 gen species_itis =172735
 gen units = "Thousands"
@@ -117,6 +119,9 @@ forvalues class =0/7{
 
 
 }
+
+collapse (mean) age*, by(year)
+
 
 gen fishery= "SFSBSB"
 gen common= "SCUP"
@@ -151,7 +156,7 @@ gen common= "SCUP"
 gen state=""
 gen wave=.
 gen metric="2026 Projected Numbers At Age"
-gen source = "2024 Assessment"
+gen source = "2025 Assessment"
 gen stock_abbrev = ""
 gen species_itis =169182
 gen units = "Thousands"
@@ -171,10 +176,13 @@ save "$misc_data_cd/`Scup_projected_filename'", replace
 /* Assessment */
 /*******************************************************/
 import delimited using "$misc_data_cd/`bsb_assessS'", clear
+capture drop year
+gen year=2024
 
 forvalues i = 1/8 {
     rename v`i' age`i'    
 }
+collapse (mean) age*, by(year)
 
 
 gen fishery= "SFSBSB"
@@ -182,15 +190,13 @@ gen common= "BLACK SEA BASS"
 gen state=""
 gen wave=.
 gen metric="2024 Numbers at Age"
-gen source = "2024 Assessment"
+gen source = "2025 Assessment"
 gen stock_abbrev = "SOUTH"
 gen species_itis =167687
 gen units = "Thousands"
 gen str data_version= "`vintage_string'"
 
 duplicates drop 
-capture drop year
-gen year=2024
 sample $ndraws, count
 capture drop draw
 
@@ -198,26 +204,27 @@ save "$misc_data_cd/`BSB_South_historical_filename'", replace
 
 
 import delimited using "$misc_data_cd/`bsb_assessN'", clear
+capture drop year
+gen year=2024
 
 forvalues i = 1/8 {
     rename v`i' age`i'    
 }
 
+collapse (mean) age*, by(year)
 
 gen fishery= "SFSBSB"
 gen common= "BLACK SEA BASS"
 gen state=""
 gen wave=.
 gen metric="2024 Numbers at Age"
-gen source = "2024 Assessment"
+gen source = "2025 Assessment"
 gen stock_abbrev = "NORTH"
 gen species_itis =167687
 gen units = "Thousands"
 gen str data_version= "`vintage_string'"
 
 duplicates drop 
-capture drop year
-gen year=2024
 sample $ndraws, count
 capture drop draw
 
@@ -237,12 +244,13 @@ forvalues i = 1/8 {
 }
 
 
+
 gen fishery= "SFSBSB"
 gen common= "BLACK SEA BASS"
 gen state=""
 gen wave=.
 gen metric="2026 Numbers at Age"
-gen source = "2024 Assessment"
+gen source = "2025 Assessment"
 gen stock_abbrev = "SOUTH"
 gen species_itis =167687
 gen units = "Thousands"
@@ -269,7 +277,7 @@ gen common= "BLACK SEA BASS"
 gen state=""
 gen wave=.
 gen metric="2026 Numbers at Age"
-gen source = "2024 Assessment"
+gen source = "2025 Assessment"
 gen stock_abbrev = "NORTH"
 gen species_itis =167687
 gen units = "Thousands"

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -1,0 +1,292 @@
+* stock assessment numbers-at-age data
+	* Min-Yang processes the historical numbers-at-age data and makes projections, and stores his output in Google Drive
+	* Here I pull that data from Google Drive (using the Desktop app file path) and save it with a generic name in a local folder 
+
+local date: display %td_CCYY_NN_DD date(c(current_date), "DMY")
+local today_date_string = subinstr(trim("`date'"), " " , "_", .)
+local vintage_string `today_date_string'
+
+
+local google_folder "D:/Shared drives/NMFS NEC READ SSB/socialsci/RecreationalDST/2028_management_cycle_data/flukeRDM/input_data"
+
+/* will need to adjust this to match actual file names*/
+
+
+
+/* input csvs */
+local bsb_assessN  "fit_NAA_NORTH_2024.csv"
+local bsb_assessS  "fit_NAA_SOUTH_2024.csv"
+local bsb_projectN  "fit_proj_NAA_NORTH_2026.csv"
+local bsb_projectS "fit_proj_NAA_SOUTH_2026"
+
+local scup_assess  "J1_2024Scup.csv"
+local scup_project  "J1_2026Scup.csv"
+
+local sf_assess  "J1_2024Summer_Flounder.csv"
+local sf_project  "J1_2026Summer_Flounder.csv"
+
+/*output filenames */
+local SF_projected_filename "SummerFlounder_projected_NAA_`vintage_string'.dta"
+local SF_historical_filename "SummerFlounder_historical_NAA_`vintage_string'.dta"
+
+local Scup_projected_filename "Scup_projected_NAA_`vintage_string'.dta"
+local Scup_historical_filename "Scup_historical_NAA_`vintage_string'.dta"
+
+local BSB_South_projected_filename "BlackSeaBass_South_projected_NAA_`vintage_string'.dta"
+local BSB_South_historical_filename "BlackSeaBass_South_historical_NAA_`vintage_string'.dta"
+
+local BSB_North_projected_filename "BlackSeaBass_South_projected_NAA_`vintage_string'.dta"
+local BSB_North_historical_filename "BlackSeaBass_South_historical_NAA_`vintage_string'.dta"
+
+
+set seed 12345
+
+/* Process stock assessment */
+/* Summer flounder */
+import delimited using "$misc_data_cd/`sf_assess'", clear
+
+
+foreach var of varlist a0-a7{
+	replace `var'=`var'/1000
+}
+
+gen fishery= "SFSBSB"
+gen common= "SUMMER FLOUNDER"
+gen state=""
+gen wave=.
+gen metric="2024 Numbers at Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =172735
+gen units = "Thousands"
+gen region  = "CST"
+gen str data_version= "`vintage_string'"
+
+duplicates drop 
+assert year==2024
+drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`SF_historical_filename'.dta", replace
+
+
+import delimited using "$misc_data_cd/`sf_project'", clear
+
+foreach var of varlist a0-a7{
+	replace `var'=`var'/1000
+}
+
+gen fishery= "SFSBSB"
+gen common= "SUMMER FLOUNDER"
+gen state=""
+gen wave=.
+gen metric="2026 Projected Numbers At Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =172735
+gen units = "Thousands"
+gen region  = "CST"
+gen str data_version= "`vintage_string'"
+
+duplicates drop 
+assert year==2026
+
+drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`SF_projected_filename'.dta", replace
+
+/*******************************************************/
+/* SCUP */
+/*******************************************************/
+import delimited using "$misc_data_cd/`scup_assess'", clear
+
+
+foreach var of varlist a0-a7{
+	replace `var'=`var'/1000
+}
+
+gen fishery= "SFSBSB"
+gen common= "SCUP"
+gen state=""
+gen wave=.
+gen metric="2024 Numbers at Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =172735
+gen units = "Thousands"
+gen region  = "CST"
+gen str data_version= "`vintage_string'"
+
+duplicates drop 
+assert year==2024
+drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`Scup_historical_filename'.dta", replace
+
+
+import delimited using "$misc_data_cd/`scup_project'", clear
+
+foreach var of varlist a0-a7{
+	replace `var'=`var'/1000
+}
+
+gen fishery= "SFSBSB"
+gen common= "SCUP"
+gen state=""
+gen wave=.
+gen metric="2026 Projected Numbers At Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =169182
+gen units = "Thousands"
+gen region  = "CST"
+gen str data_version= "`vintage_string'"
+
+duplicates drop
+assert year==2026 
+drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`Scup_projected_filename'.dta", replace
+
+
+
+/*******************************************************/
+/* Black Sea Bass */
+/* Assessment */
+/*******************************************************/
+import delimited using "$misc_data_cd/`bsb_assessS'", clear
+
+forv i = 1/8 {
+    rename v`i' a`i'    
+}
+
+
+gen fishery= "SFSBSB"
+gen common= "BLACK SEA BASS"
+gen state=""
+gen wave=.
+gen metric="2024 Numbers at Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =167687
+gen units = "Thousands"
+gen region  = "SOUTH"
+gen str data_version= "`vintage_string'"
+
+duplicates drop 
+capture drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`BSB_South_historical_filename'.dta", replace
+
+
+import delimited using "$misc_data_cd/`bsb_assessN'", clear
+
+forv i = 1/8 {
+    rename v`i' a`i'    
+}
+
+
+gen fishery= "SFSBSB"
+gen common= "BLACK SEA BASS"
+gen state=""
+gen wave=.
+gen metric="2024 Numbers at Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =167687
+gen units = "Thousands"
+gen region  = "NORTH"
+gen str data_version= "`vintage_string'"
+
+duplicates drop 
+capture drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`BSB_North_historical_filename'.dta", replace
+
+
+
+/*******************************************************/
+/* Black Sea Bass */
+/* Assessment */
+/*******************************************************/
+
+import delimited using "$misc_data_cd/`bsb_projectS'", clear
+
+forv i = 1/8 {
+    rename v`i' a`i'    
+}
+
+
+gen fishery= "SFSBSB"
+gen common= "BLACK SEA BASS"
+gen state=""
+gen wave=.
+gen metric="2024 Numbers at Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =167687
+gen units = "Thousands"
+gen region  = "SOUTH"
+gen str data_version= "`vintage_string'"
+
+duplicates drop 
+capture drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`BSB_South_projected_filename'.dta", replace
+
+
+import delimited using "$misc_data_cd/`bsb_projectN'", clear
+
+forv i = 1/8 {
+    rename v`i' a`i'    
+}
+
+
+gen fishery= "SFSBSB"
+gen common= "BLACK SEA BASS"
+gen state=""
+gen wave=.
+gen metric="2026 Numbers at Age"
+gen source = "2024 Assessment"
+gen stock_abbrev = ""
+gen species_itis =167687
+gen units = "Thousands"
+gen region  = "NORTH"
+gen str data_version= "`vintage_string'"
+
+duplicates drop 
+capture drop year
+sample $ndraws, count
+
+save "$misc_data_cd/`BSB_North_projected_filename'.dta", replace
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -26,17 +26,17 @@ local sf_assess  "J1_2024Summer_Flounder.csv"
 local sf_project  "J1_2026Summer_Flounder.csv"
 
 /*output filenames */
-local SF_projected_filename "SummerFlounder_projected_NAA_`vintage_string'.dta"
-local SF_historical_filename "SummerFlounder_historical_NAA_`vintage_string'.dta"
+local SF_projected_filename "SummerFlounder_projectedNAA_`vintage_string'.dta"
+local SF_historical_filename "SummerFlounder_historicalNAA_`vintage_string'.dta"
 
-local Scup_projected_filename "Scup_projected_NAA_`vintage_string'.dta"
-local Scup_historical_filename "Scup_historical_NAA_`vintage_string'.dta"
+local Scup_projected_filename "Scup_projectedNAA_`vintage_string'.dta"
+local Scup_historical_filename "Scup_historicalNAA_`vintage_string'.dta"
 
-local BSB_South_projected_filename "BlackSeaBass_South_projected_NAA_`vintage_string'.dta"
-local BSB_South_historical_filename "BlackSeaBass_South_historical_NAA_`vintage_string'.dta"
+local BSB_South_projected_filename "BlackSeaBassSouth_projectedNAA_`vintage_string'.dta"
+local BSB_South_historical_filename "BlackSeaBassSouth_historicalNAA_`vintage_string'.dta"
 
-local BSB_North_projected_filename "BlackSeaBass_South_projected_NAA_`vintage_string'.dta"
-local BSB_North_historical_filename "BlackSeaBass_South_historical_NAA_`vintage_string'.dta"
+local BSB_North_projected_filename "BlackSeaBassSouth_projectedNAA_`vintage_string'.dta"
+local BSB_North_historical_filename "BlackSeaBassSouth_historicalNAA_`vintage_string'.dta"
 
 
 set seed 12345

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -67,7 +67,7 @@ assert year==2024
 drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`SF_historical_filename'.dta", replace
+save "$misc_data_cd/`SF_historical_filename'", replace
 
 
 import delimited using "$misc_data_cd/`sf_project'", clear
@@ -94,7 +94,7 @@ assert year==2026
 drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`SF_projected_filename'.dta", replace
+save "$misc_data_cd/`SF_projected_filename'", replace
 
 /*******************************************************/
 /* SCUP */
@@ -123,7 +123,7 @@ assert year==2024
 drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`Scup_historical_filename'.dta", replace
+save "$misc_data_cd/`Scup_historical_filename'", replace
 
 
 import delimited using "$misc_data_cd/`scup_project'", clear
@@ -149,7 +149,7 @@ assert year==2026
 drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`Scup_projected_filename'.dta", replace
+save "$misc_data_cd/`Scup_projected_filename'", replace
 
 
 
@@ -180,7 +180,7 @@ duplicates drop
 capture drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`BSB_South_historical_filename'.dta", replace
+save "$misc_data_cd/`BSB_South_historical_filename'", replace
 
 
 import delimited using "$misc_data_cd/`bsb_assessN'", clear
@@ -206,7 +206,7 @@ duplicates drop
 capture drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`BSB_North_historical_filename'.dta", replace
+save "$misc_data_cd/`BSB_North_historical_filename'", replace
 
 
 
@@ -238,7 +238,7 @@ duplicates drop
 capture drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`BSB_South_projected_filename'.dta", replace
+save "$misc_data_cd/`BSB_South_projected_filename'", replace
 
 
 import delimited using "$misc_data_cd/`bsb_projectN'", clear
@@ -264,29 +264,4 @@ duplicates drop
 capture drop year
 sample $ndraws, count
 
-save "$misc_data_cd/`BSB_North_projected_filename'.dta", replace
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+save "$misc_data_cd/`BSB_North_projected_filename'", replace

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -146,7 +146,7 @@ save "$misc_data_cd/`Scup_historical_filename'", replace
 import delimited using "$misc_data_cd/`scup_project'", clear
 
 forvalues class =0/7{
-	replace a`class'=`class'/1000
+	replace a`class'=a`class'/1000
 	rename a`class' age`class'
 
 }

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -59,12 +59,15 @@ forvalues class =0/7{
 	rename a`class' age`class'
 
 }
+assert year==2024
+
+collapse (mean) age*, by(year)
 
 gen fishery= "SFSBSB"
 gen common= "SUMMER FLOUNDER"
 gen state=""
 gen wave=.
-gen metric="2024 Numbers at Age"
+gen metric="Historical Mean Numbers of Age"
 gen source = "2025 Assessment"
 gen stock_abbrev = ""
 gen species_itis =172735
@@ -73,9 +76,7 @@ gen region  = "CST"
 gen str data_version= "`vintage_string'"
 
 duplicates drop 
-assert year==2024
-sample $ndraws, count
-assert _N==$ndraws
+
 
 capture drop draw
 save "$misc_data_cd/`SF_historical_filename'", replace
@@ -120,13 +121,17 @@ forvalues class =0/7{
 
 
 }
+assert year==2024
+
+collapse (mean) age*, by(year)
+
 
 
 gen fishery= "SFSBSB"
 gen common= "SCUP"
 gen state=""
 gen wave=.
-gen metric="2024 Numbers at Age"
+gen metric="Historical Mean Numbers of Age"
 gen source = "2024 Assessment"
 gen stock_abbrev = ""
 gen species_itis =172735
@@ -136,8 +141,6 @@ gen str data_version= "`vintage_string'"
 
 duplicates drop 
 assert year==2024
-sample $ndraws, count
-assert _N==$ndraws
 
 capture drop draw
 
@@ -185,23 +188,18 @@ gen year=2024
 forvalues i = 1/8 {
     rename v`i' age`i'    
 }
+collapse (mean) age*, by(year)
 
 gen fishery= "SFSBSB"
 gen common= "BLACK SEA BASS"
 gen state=""
 gen wave=.
-gen metric="2024 Numbers at Age"
+gen metric="Historical Mean Numbers of Age"
 gen source = "2025 Assessment"
 gen stock_abbrev = "SOUTH"
 gen species_itis =167687
 gen units = "Thousands"
 gen str data_version= "`vintage_string'"
-
-duplicates drop 
-sample $ndraws, count
-assert _N==$ndraws
-
-capture drop draw
 
 save "$misc_data_cd/`BSB_South_historical_filename'", replace
 
@@ -214,23 +212,19 @@ forvalues i = 1/8 {
     rename v`i' age`i'    
 }
 
+collapse (mean) age*, by(year)
+
 
 gen fishery= "SFSBSB"
 gen common= "BLACK SEA BASS"
 gen state=""
 gen wave=.
-gen metric="2024 Numbers at Age"
+gen metric="Historical Mean Numbers of Age"
 gen source = "2025 Assessment"
 gen stock_abbrev = "NORTH"
 gen species_itis =167687
 gen units = "Thousands"
 gen str data_version= "`vintage_string'"
-
-duplicates drop 
-sample $ndraws, count
-assert _N==$ndraws
-
-capture drop draw
 
 save "$misc_data_cd/`BSB_North_historical_filename'", replace
 

--- a/Code/pre_sim/rdb_processing_NAA.do
+++ b/Code/pre_sim/rdb_processing_NAA.do
@@ -59,8 +59,6 @@ forvalues class =0/7{
 	rename a`class' age`class'
 
 }
-collapse (mean) age*, by(year)
-
 
 gen fishery= "SFSBSB"
 gen common= "SUMMER FLOUNDER"
@@ -77,6 +75,8 @@ gen str data_version= "`vintage_string'"
 duplicates drop 
 assert year==2024
 sample $ndraws, count
+assert _N==$ndraws
+
 capture drop draw
 save "$misc_data_cd/`SF_historical_filename'", replace
 
@@ -105,6 +105,7 @@ duplicates drop
 assert year==2026
 
 sample $ndraws, count
+assert _N==$ndraws
 
 save "$misc_data_cd/`SF_projected_filename'", replace
 
@@ -119,8 +120,6 @@ forvalues class =0/7{
 
 
 }
-
-collapse (mean) age*, by(year)
 
 
 gen fishery= "SFSBSB"
@@ -138,6 +137,8 @@ gen str data_version= "`vintage_string'"
 duplicates drop 
 assert year==2024
 sample $ndraws, count
+assert _N==$ndraws
+
 capture drop draw
 
 save "$misc_data_cd/`Scup_historical_filename'", replace
@@ -166,6 +167,8 @@ gen str data_version= "`vintage_string'"
 duplicates drop
 assert year==2026 
 sample $ndraws, count
+assert _N==$ndraws
+
 
 save "$misc_data_cd/`Scup_projected_filename'", replace
 
@@ -182,8 +185,6 @@ gen year=2024
 forvalues i = 1/8 {
     rename v`i' age`i'    
 }
-collapse (mean) age*, by(year)
-
 
 gen fishery= "SFSBSB"
 gen common= "BLACK SEA BASS"
@@ -198,6 +199,8 @@ gen str data_version= "`vintage_string'"
 
 duplicates drop 
 sample $ndraws, count
+assert _N==$ndraws
+
 capture drop draw
 
 save "$misc_data_cd/`BSB_South_historical_filename'", replace
@@ -211,7 +214,6 @@ forvalues i = 1/8 {
     rename v`i' age`i'    
 }
 
-collapse (mean) age*, by(year)
 
 gen fishery= "SFSBSB"
 gen common= "BLACK SEA BASS"
@@ -226,6 +228,8 @@ gen str data_version= "`vintage_string'"
 
 duplicates drop 
 sample $ndraws, count
+assert _N==$ndraws
+
 capture drop draw
 
 save "$misc_data_cd/`BSB_North_historical_filename'", replace
@@ -260,6 +264,7 @@ duplicates drop
 capture drop year
 gen year=2026
 sample $ndraws, count
+assert _N==$ndraws
 capture drop draw
 
 save "$misc_data_cd/`BSB_South_projected_filename'", replace
@@ -287,6 +292,8 @@ duplicates drop
 capture drop year
 gen year=2026
 sample $ndraws, count
+assert _N==$ndraws
+
 capture drop draw
 
 save "$misc_data_cd/`BSB_North_projected_filename'", replace


### PR DESCRIPTION
Code wrangle SF, S, and BSB into the dataformat needed for the the dashboard. to test:


```
cd $flukeRDMdir
doedit "$flukeRDMdir\Code\pre_sim\model_wrapper.do"

/*manually adjust these execution control */
// Control which modules to run (set to 0 to skip)
loc pull_assessment = 1		 		// Pull Assessment data
loc prep_NAA_for_dashboard = 1		// Pull Assessment data
loc push_NAA_to_gdrive =1 			// Convert Assessment data to Rds, reshape to long, and push to googledrive
loc processMRIP = 0		 			// deal with casing MRIP data
loc assemblemriplists =0		 	// deal with casing MRIP data

loc estimate_dtrips = 0			// Estimate Directed Trips 
loc costs_per_trip = 0			// Create Distributions of costs per trip (run 1x)
loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
loc catch_per_trip1 = 0				// Part 1 of catch per trip
loc copula_in_R = 0					// Copula model in R
loc catch_per_trip2 = 0				// Part 2 of catch per trip
loc compare_calibration_MRIP = 0	// compare calibration output to MRIP
loc prep_cpt_for_dashboard= 0		// prep data for dashboard NOT IN WRAPPER. NOT WRITTEN, See Groundfish repo
loc Rpush_to_gdrive =0 				// Push to google drive in R NOT IN WRAPPER. WRITTEN but not tested 
loc angler_demogs	=0				// add additonal angler demographics
loc generate_baseline=0				// Generate baseline-year catch-at-length
loc catch_at_length_project=0		// Generate projection-year catch-at-length
loc catch_per_trip_project=0       // Generate projection-year catch-per trip

do "$flukeRDMdir\Code\pre_sim\model_wrapper.do"
```