### PR TITLE
replace the near identical blocks with a loop.

### DIFF
--- a/Run_Model.R
+++ b/Run_Model.R
@@ -18,85 +18,14 @@ args <- commandArgs(trailingOnly = TRUE)
 saved_regs<- read.csv(here::here(paste0("saved_regs/regs_", args[1], ".csv")))
 
 
-## Massachusetts
-if(any(grepl("ma", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("ma", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "ma")
-}
+states <- c("ma", "ri", "ct", "ny", "nj", "de", "md", "va", "nc")
 
-## Rhode Island
-if(any(grepl("ri", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("ri", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "ri")
-}
-
-## Connecticut
-if(any(grepl("ct", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("ct", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "ct")
-}
-
-## New York
-if(any(grepl("ny", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("ny", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "ny")
-}
-
-## New Jersey
-if(any(grepl("nj", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("nj", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "nj")
-}
-
-## Deleware
-if(any(grepl("de", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("de", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "de")
-}
-
-## Maryland
-if(any(grepl("md", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("md", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "md")
-}
-
-## Virginia
-if(any(grepl("va", saved_regs$input))){
-  
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("va", saved_regs$input))
-  
-  run_state_model(Run_Name, state = "va")
-}
-
-# North Carolina
-if(any(grepl("nc", saved_regs$input))){
-
-  save_regs <- saved_regs %>%
-    dplyr::filter(grepl("nc", saved_regs$input))
-
-  run_state_model(Run_Name, state = "nc")
+for (st in states) {
+  if (any(grepl(st, saved_regs$input))) {
+    save_regs <- saved_regs %>%
+      dplyr::filter(grepl(st, saved_regs$input))
+    run_state_model(Run_Name, state = st)
+  }
 }
 
 


### PR DESCRIPTION
As an aside:


```
    save_regs <- saved_regs %>%
      dplyr::filter(grepl(st, saved_regs$input))
```

I'm not sure this does anything.  Te only reference I see to 'save_regs' is in compare_savedregs_output.R 

run_state_model reads in a new `saved_regs`

https://github.com/kimberly-bastille/flukeRDM/blob/f900266dbf1eaa7af651ff0160a76eb5f02e5b1f/Code/sim/run_state_model.R#L9


