### PR TITLE
Integrate mrip pull

### DIFF
--- a/Code/pre_sim/directed_trips_calibration.do
+++ b/Code/pre_sim/directed_trips_calibration.do
@@ -140,10 +140,11 @@ gen day1=substr(date, 7, 2)
 drop if inlist(day1,"9x", "xx") 
 destring day1, replace
 
+/* handled in get_mrip_oracle
 gen mode1="sh" if inlist(mode_fx, "1", "2", "3")
 replace mode1="pr" if inlist(mode_fx, "7")
 replace mode1="fh" if inlist(mode_fx, "4", "5")
-
+*/
 
 // Deal with Group Catch: 
 	// This bit of code generates a flag for each year-strat_id psu_id leader. (equal to the lowest of the dom_id)
@@ -726,10 +727,11 @@ gen day1=substr(date, 7, 2)
 drop if inlist(day1,"9x", "xx") 
 destring day1, replace
 
+/* handled in get_mrip_oracle
 gen mode1="sh" if inlist(mode_fx, "1", "2", "3")
 replace mode1="pr" if inlist(mode_fx, "7")
 replace mode1="fh" if inlist(mode_fx, "4", "5")
-
+*/
 
 // Deal with Group Catch: 
 	// This bit of code generates a flag for each year-strat_id psu_id leader. (equal to the lowest of the dom_id)
@@ -867,11 +869,11 @@ gen month1=substr(date, 5, 2)
 gen day1=substr(date, 7, 2)
 drop if inlist(day1,"9x", "xx") 
 destring day1, replace
-
+/* handled in get_mrip_oracle)
 gen mode1="sh" if inlist(mode_fx, "1", "2", "3")
 replace mode1="pr" if inlist(mode_fx, "7")
 replace mode1="fh" if inlist(mode_fx, "4", "5")
-
+*/
 
 // Deal with Group Catch: 
 	// This bit of code generates a flag for each year-strat_id psu_id leader. (equal to the lowest of the dom_id)
@@ -1008,10 +1010,11 @@ gen day1=substr(date, 7, 2)
 drop if inlist(day1,"9x", "xx") 
 destring day1, replace
 
+/* handled in get mrip_oracle
 gen mode1="sh" if inlist(mode_fx, "1", "2", "3")
 replace mode1="pr" if inlist(mode_fx, "7")
 replace mode1="fh" if inlist(mode_fx, "4", "5")
-
+*/
 
 // Deal with Group Catch: 
 	// This bit of code generates a flag for each year-strat_id psu_id leader. (equal to the lowest of the dom_id)
@@ -1153,11 +1156,11 @@ gen month1=substr(date, 5, 2)
 gen day1=substr(date, 7, 2)
 drop if inlist(day1,"9x", "xx") 
 destring day1, replace
-
+/* handled in get_mrip_oracle
 gen mode1="sh" if inlist(mode_fx, "1", "2", "3")
 replace mode1="pr" if inlist(mode_fx, "7")
 replace mode1="fh" if inlist(mode_fx, "4", "5")
-
+*/
 
 // Deal with Group Catch: 
 	// This bit of code generates a flag for each year-strat_id psu_id leader. (equal to the lowest of the dom_id)

--- a/Code/pre_sim/directed_trips_calibration.do
+++ b/Code/pre_sim/directed_trips_calibration.do
@@ -128,7 +128,10 @@ replace dom_id="1" if strmatch(common, "scup")
 replace dom_id="1" if strmatch(prim1_common, "scup") 
 
 * keep only NC north based on county delineation from Tracey 
-replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+* replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+
+* all STOCK_REGION_CALC=="SOUTH" is south of Hatteras
+replace dom_id="2"  if STOCK_REGION_CALC=="SOUTH"
 
 
 tostring wave, gen(w2)
@@ -716,7 +719,10 @@ replace dom_id="1" if strmatch(common, "scup")
 replace dom_id="1" if strmatch(prim1_common, "scup") 
 
 * keep only NC north based on county delineation from Tracey 
-replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+* replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+
+* all STOCK_REGION_CALC=="SOUTH" is south of Hatteras
+replace dom_id="2"  if STOCK_REGION_CALC=="SOUTH"
 
 tostring wave, gen(w2)
 tostring year, gen(year2)
@@ -858,7 +864,10 @@ replace dom_id="1" if strmatch(common, "scup")
 replace dom_id="1" if strmatch(prim1_common, "scup") 
 
 * keep only NC north based on county delineation from Tracey 
-replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+* replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+
+* all STOCK_REGION_CALC=="SOUTH" is south of Hatteras
+replace dom_id="2"  if STOCK_REGION_CALC=="SOUTH"
 
 
 tostring wave, gen(w2)
@@ -999,7 +1008,10 @@ replace dom_id="1" if strmatch(common, "scup")
 replace dom_id="1" if strmatch(prim1_common, "scup") 
 
 * keep only NC north based on county delineation from Tracey 
-replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+* replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+
+* all STOCK_REGION_CALC=="SOUTH" is south of Hatteras
+replace dom_id="2"  if STOCK_REGION_CALC=="SOUTH"
 
 tostring wave, gen(w2)
 tostring year, gen(year2)
@@ -1145,7 +1157,10 @@ replace dom_id="1" if strmatch(common, "scup")
 replace dom_id="1" if strmatch(prim1_common, "scup") 
 
 * keep only NC north based on county delineation from Tracey 
-replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+* replace dom_id="2"  if state=="NC" & !inlist(cnty, 15, 29, 41, 53, 55, 139, 143, 177, 187)
+
+* all STOCK_REGION_CALC=="SOUTH" is south of Hatteras
+replace dom_id="2"  if STOCK_REGION_CALC=="SOUTH"
 
 
 tostring wave, gen(w2)

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -6,9 +6,9 @@
 #               character, and writes per-element .dta files plus a combined .Rds.
 # Inputs:       Command-line args: first_year last_year. Live Oracle connection
 #               (mriptacklebox's nefscdb_con).
-# Outputs:      <gf.data.dir>/miscellaneous/mrip_{trip,catch,size,size_b2}.dta and
+# Outputs:      <sf.data.dir>/miscellaneous/mrip_{trip,catch,size,size_b2}.dta and
 #               mrip_pull<today>.Rds.
-# Dependencies: Sources developer_setup.R (for gf.data.dir). Requires Oracle
+# Dependencies: Sources developer_setup.R (for sf.data.dir). Requires Oracle
 #               access to MRIP data tables and RECDBS schema
 # Pipeline:     Step 2 of model_wrapper.do (gated by pull_MRIP), invoked via
 #               `rscript using ... args(first last)`, and followed immediately by
@@ -53,7 +53,7 @@ conflicts_prefer(dplyr::lag)
 # standard "here", username setup, and paths
 here::i_am("Code/pre_sim/get_mrip_oracle.R")
 source(here("Code", "helpers", "developer_setup.R"))
-output_folder<-file.path(gf.data.dir, "miscellaneous")
+output_folder<-file.path(sf.data.dir, "miscellaneous")
 
 #for help with versioning
 todaysdate<-Sys.Date()
@@ -74,35 +74,27 @@ mrip_pull <- mrip_microdata(
   format = c('nefsc_db'),
   nefsc_db_con=con_name
 )
+
+
 message("MRIP microdata from Oracle read in...")
 
 
+message("Constructing NC site list")
+message("This is the ASMFC version and is slightly different from the MRIP tacklebox.")
 
-message("Pulling Site List from Oracle...")
-
-new_site_list<-glue("select * from RECDBS.MRIP_COD_ALL_SITE_LIST")
-site_list<-dbGetQuery(con_name, new_site_list)
-dbDisconnect(con_name)
-
-message("Processing MA and ME Sites")
-site_list_WGOM_COD<-site_list %>%
-  filter(STATE %in% c("MA", "ME")) %>%
-  select(c(STATE, INTSITE, NMFS_STOCK_AREA, NMFS_STAT_AREA))  %>%
-  mutate(NMFS_STOCK_AREA=case_when(
-    NMFS_STAT_AREA %in% c("521", "526", "541", "514", "513", "515") ~ "WGOM",
-    TRUE ~ "XX"
+nc_county_split <-dplyr::bind_rows(
+    tibble::tibble(
+      STATE_CODE="37",#North Carolina
+      CNTY = c("015","029", "041", "053", "055", "139", "143", "177", "187"),
+      STOCK_REGION_CALC ="NORTH"
+    ),
+    tibble::tibble(
+      STATE_CODE="37", #North Carolina
+      CNTY =  c("013", "019", "031", "049", "095", "129", "133", "137", "141", "147") ,
+      STOCK_REGION_CALC = "SOUTH"
     )
-  ) %>%
-  distinct()
-
-
+  ) 
 message("Data Munging")
-
-# append a mrip_pull_date column (today's date) to every element, formatted as
-# "Month DD, YYYY" (the %B %d, %Y example renders e.g. as "July 16, 2026")
-mrip_pull <- map(mrip_pull, ~ mutate(
-  .x, MRIP_PULL_DATE =as.character(format(todaysdate,"%B %d, %Y") ) )
-)
 
 # Consolidate modes
 mrip_pull <- map(mrip_pull, ~ mutate(
@@ -114,20 +106,19 @@ mrip_pull <- map(mrip_pull, ~ mutate(
   )
 )
 
-#Bring the site list info into trip
-#Everything not in WGOM is allocated to XX, but they could be allocated to other stockareas
-#If you had the definitions.
+# Bring the site list info into trip
+# The dividing line is part of the way into NC. not north of this is allocated to South, but that includes HI, just to conserve on domains.
+
 mrip_pull$trip <- mrip_pull$trip %>%
   left_join(
-  site_list_WGOM_COD, by=join_by(INTSITE==INTSITE, ST_ABB==STATE)
+    nc_county_split, by=join_by(CNTY==CNTY, ST==STATE_CODE)
   ) %>%
-  mutate(AREA_S=case_when(
-    ST =="33" ~ "WGOM",
-    ST %in%  c("25","23") ~ NMFS_STOCK_AREA,
-    TRUE ~ "XX"
-  )) %>%
-    select(-c("NMFS_STAT_AREA","NMFS_STOCK_AREA")
-)
+  mutate(STOCK_REGION_CALC=case_when(
+    ST %in%  c("37") ~ STOCK_REGION_CALC,
+    ST %in%  c("09","10","23","24","25","33","34","36","44","51") ~ "NORTH",
+    ST %in%  c("01","12","13","15","28","45") ~ "SOUTH", # I'm binning everything that isn't North into South.
+    TRUE ~ "SOUTH"
+  )) 
 
 # append the mrip_pull_date to the mrip_pull list as a tibble
 
@@ -159,6 +150,10 @@ mrip_pull <- map(mrip_pull, ~ mutate(
   .x, across(c(strat_id, psu_id, id_code,zip), as.character))
   )
 
+  
+mrip_pull$trip <- mrip_pull$trip %>%
+	mutate(cnty=as.numeric(cnty))
+  
 # You might need to delete a few columns of of data if the downstream stata code doesn't work.
 #MODE1, AREA_S
 

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -1,0 +1,173 @@
+################################################################################
+# Script:       get_mrip_oracle.R
+# Purpose:      Pulls MRIP recreational microdata (trip, catch, size, size_b2)
+#               from Oracle via the mriptacklebox package for a year range,
+#               lower-cases names, stamps a pull date, forces id columns to
+#               character, and writes per-element .dta files plus a combined .Rds.
+# Inputs:       Command-line args: first_year last_year. Live Oracle connection
+#               (mriptacklebox's nefscdb_con).
+# Outputs:      <gf.data.dir>/miscellaneous/mrip_{trip,catch,size,size_b2}.dta and
+#               mrip_pull<today>.Rds.
+# Dependencies: Sources developer_setup.R (for gf.data.dir). Requires Oracle
+#               access to MRIP data tables and RECDBS schema
+# Pipeline:     Step 2 of model_wrapper.do (gated by pull_MRIP), invoked via
+#               `rscript using ... args(first last)`, and followed immediately by
+#               tidyup_mrip_data_fromR.do. Also runnable standalone:
+#               Rscript get_mrip_oracle.R 2023 2025.
+################################################################################
+
+
+# Define arguments
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2) {
+  stop("Error: This script requires exactly two arguments.", call. = FALSE)
+}
+
+#read in arguments. Ensure they are numeric
+first_yr  <- as.numeric(args[1])
+last_yr   <-  as.numeric(args[2])
+#first_yr<-2023
+#last_yr<-2025
+
+# Show them, just in case.
+cat("First Year:", first_yr, "\n")
+cat("Last Year:", last_yr, "\n")
+
+
+# Load libraries
+# install the main branch
+#remotes::install_github("NEFSC/READ-PDB-mriptacklebox")
+
+library("here")
+library("mriptacklebox")
+library("ROracle")
+library("tidyverse")
+library("DBI")
+library("glue")
+library("haven")
+library("conflicted")
+conflicts_prefer(dplyr::filter)
+conflicts_prefer(dplyr::lag)
+
+
+# standard "here", username setup, and paths
+here::i_am("Code/pre_sim/get_mrip_oracle.R")
+source(here("Code", "helpers", "developer_setup.R"))
+output_folder<-file.path(gf.data.dir, "miscellaneous")
+
+#for help with versioning
+todaysdate<-Sys.Date()
+
+# Connect to Oracle
+drv<-dbDriver("Oracle")
+con_name<-eval(nefscdb_con)
+
+
+yearlist<-first_yr:last_yr
+wavelist<-1:6
+
+# pull data and then disconnect
+message("Pulling MRIP microdata from Oracle (this can take a while) ...")
+mrip_pull <- mrip_microdata(
+  years = yearlist, waves = wavelist,
+  typ = c('trip', 'catch', 'size', 'size_b2'),
+  format = c('nefsc_db'),
+  nefsc_db_con=con_name
+)
+message("MRIP microdata from Oracle read in...")
+
+
+
+message("Pulling Site List from Oracle...")
+
+new_site_list<-glue("select * from RECDBS.MRIP_COD_ALL_SITE_LIST")
+site_list<-dbGetQuery(con_name, new_site_list)
+dbDisconnect(con_name)
+
+message("Processing MA and ME Sites")
+site_list_WGOM_COD<-site_list %>%
+  filter(STATE %in% c("MA", "ME")) %>%
+  select(c(STATE, INTSITE, NMFS_STOCK_AREA, NMFS_STAT_AREA))  %>%
+  mutate(NMFS_STOCK_AREA=case_when(
+    NMFS_STAT_AREA %in% c("521", "526", "541", "514", "513", "515") ~ "WGOM",
+    TRUE ~ "XX"
+    )
+  ) %>%
+  distinct()
+
+
+message("Data Munging")
+
+# append a mrip_pull_date column (today's date) to every element, formatted as
+# "Month DD, YYYY" (the %B %d, %Y example renders e.g. as "July 16, 2026")
+mrip_pull <- map(mrip_pull, ~ mutate(
+  .x, MRIP_PULL_DATE =as.character(format(todaysdate,"%B %d, %Y") ) )
+)
+
+# Consolidate modes
+mrip_pull <- map(mrip_pull, ~ mutate(
+  .x, MODE1 =case_when(
+    MODE_FX %in% c("1","2","3") ~ "sh",
+    MODE_FX %in% c("7") ~ "pr",
+    MODE_FX %in% c("4","5") ~ "fh",
+    TRUE ~ "oth")
+  )
+)
+
+#Bring the site list info into trip
+#Everything not in WGOM is allocated to XX, but they could be allocated to other stockareas
+#If you had the definitions.
+mrip_pull$trip <- mrip_pull$trip %>%
+  left_join(
+  site_list_WGOM_COD, by=join_by(INTSITE==INTSITE, ST_ABB==STATE)
+  ) %>%
+  mutate(AREA_S=case_when(
+    ST =="33" ~ "WGOM",
+    ST %in%  c("25","23") ~ NMFS_STOCK_AREA,
+    TRUE ~ "XX"
+  )) %>%
+    select(-c("NMFS_STAT_AREA","NMFS_STOCK_AREA")
+)
+
+# append the mrip_pull_date to the mrip_pull list as a tibble
+
+datestamp<-as_tibble(todaysdate)
+colnames(datestamp)<-"mrip_pull_date"
+mrip_pull$mrip_pull_date<-datestamp
+
+# write this to an rds file.
+write_rds(mrip_pull, file=file.path(output_folder, glue("mrip_pull{todaysdate}.Rds")))
+
+message("First Year in Data: ",first_yr)
+message("Last Year in Data: ",last_yr)
+
+message("MRIP data successfully pulled on: ", format(todaysdate,"%B %d, %Y") )
+
+
+
+# A little data munging
+# Downstream stata code needs to be in all caps and we need to ensure the date formats are done properly
+# all lower case
+
+mrip_pull$mrip_pull_date<-NULL
+
+mrip_pull <- map(mrip_pull, ~rename_with(.x, tolower)
+                 )
+
+#force certain things to character
+mrip_pull <- map(mrip_pull, ~ mutate(
+  .x, across(c(strat_id, psu_id, id_code,zip), as.character))
+  )
+
+# You might need to delete a few columns of of data if the downstream stata code doesn't work.
+#MODE1, AREA_S
+
+
+# write all the elements of x to a dta file
+walk2(mrip_pull, names(mrip_pull), ~ write_dta(
+  .x,
+  path=file.path(output_folder, glue("mrip_{.y}.dta"))
+  )
+)
+
+

--- a/Code/pre_sim/get_mrip_trips.R
+++ b/Code/pre_sim/get_mrip_trips.R
@@ -1,0 +1,110 @@
+################################################################################
+# Script:       get_mrip_trips.R
+# Purpose:      Uses the most recent version of mrip_pullDATE.Rds to construct trips
+#               using MRIP tacklebox. Verify that MRIP tacklebox matches known good code
+#               before switching to other harder metrics (catch by weight)
+# Inputs:       mrip_pull{}.Rds
+# Outputs:      groundfish_effort{}.Rds is a list containing estimates at different definitions
+#               of effort. For the groundfishRDM, we use the item
+#                  groundfish_effort$"PRIM1|PRIM2|A|B1|B2"
+#               YEAR, WAVE, MODE, and AREA levels.
+# Dependencies: mriptacklebox
+#               Sources developer_setup.R (for gf.data.dir).
+# Pipeline:     Called by model_wrapper.do
+#                 Effort can be sent to Dashboard
+# To Do:        PSEs for Effort
+################################################################################
+
+
+# Load libraries
+# install the main branch, needs main on/after  7/29/2026
+# remotes::install_github("NEFSC/READ-PDB-mriptacklebox")
+
+library("here")
+library("mriptacklebox")
+library("tidyverse")
+library("glue")
+library("haven")
+library("conflicted")
+conflicts_prefer(dplyr::filter)
+conflicts_prefer(dplyr::lag)
+
+
+
+
+# standard "here", username setup, and paths
+here::i_am("Code/pre_sim/get_mrip_trips.R")
+source(here("Code", "helpers", "developer_setup.R"))
+
+output_folder<-file.path(gf.data.dir, "miscellaneous")
+
+vintage_string<-list.files(output_folder, pattern=glob2rx("mrip_pull*Rds"))
+vintage_string<-gsub("mrip_pull","",vintage_string)
+vintage_string<-gsub(".Rds","",vintage_string)
+data_vintage<-max(vintage_string)
+
+# write this to an rds file.
+mrip_pull<-read_rds(file=file.path(output_folder, glue("mrip_pull{data_vintage}.Rds")))
+
+# cast to upper case
+mrip_pull <- map(mrip_pull, ~rename_with(.x, toupper))
+
+# Compute Effort for different kind of targeting
+
+types<-list(
+  c('PRIM1', 'PRIM2'), # Targeting
+  'A', # landing and seen
+   c('A','B1'), # landed + dead
+  'B2', # Releases
+  c('PRIM1', 'PRIM2', 'A','B1', 'B2'), # any
+  c('A','B1', 'B2') # Any catch
+)
+list_names <- types %>%
+  map_chr(~ paste(.x, collapse = "|"))
+
+
+# Sample code to get just Cod or Just Haddock
+# targets_COD <- types %>%
+#   map(~ mrip_effort(
+#     dom = c("YEAR", "WAVE"),
+#     microdata = mrip_pull,
+#     dir_trip = list(
+#       comname = c('ATLANTIC COD'),
+#       typ = .x
+#     )
+#   )) %>%
+#   set_names(list_names)
+#
+# targets_HADDOCK <- types %>%
+#   map(~ mrip_effort(
+#     dom = c("YEAR", "WAVE"),
+#     microdata = mrip_pull,
+#     dir_trip = list(
+#       comname = c('HADDOCK'),
+#       typ = .x
+#     )
+#   )) %>%
+#   set_names(list_names)
+
+# Target or caught Either
+
+groundfish_effort <- types %>%
+  map(~ mrip_effort(
+    dom = c("YEAR", "WAVE","MODE1", "AREA_S"),
+    microdata = mrip_pull,
+    dir_trip = list(
+      comname =  c('ATLANTIC COD', 'HADDOCK'),
+      typ = .x
+    )
+  )) %>%
+  set_names(list_names)
+
+
+write_rds(groundfish_effort,file=file.path(output_folder, glue("groundfish_effort{data_vintage}.Rds")))
+
+
+# The relationship of some of the entries
+# PRIM1 : Cod + haddock=Either by definition
+# PRIM2: Same
+# Everything else: Either>= Cod, Either>=Haddock, Either<=Cod+Haddock
+

--- a/Code/pre_sim/get_mrip_trips.R
+++ b/Code/pre_sim/get_mrip_trips.R
@@ -4,12 +4,12 @@
 #               using MRIP tacklebox. Verify that MRIP tacklebox matches known good code
 #               before switching to other harder metrics (catch by weight)
 # Inputs:       mrip_pull{}.Rds
-# Outputs:      groundfish_effort{}.Rds is a list containing estimates at different definitions
-#               of effort. For the groundfishRDM, we use the item
+# Outputs:      sfs_effort{}.Rds is a list containing estimates at different definitions
+#               of effort. For the flukeRDM, we use the item
 #                  groundfish_effort$"PRIM1|PRIM2|A|B1|B2"
 #               YEAR, WAVE, MODE, and AREA levels.
 # Dependencies: mriptacklebox
-#               Sources developer_setup.R (for gf.data.dir).
+#               Sources developer_setup.R (for sf.data.dir).
 # Pipeline:     Called by model_wrapper.do
 #                 Effort can be sent to Dashboard
 # To Do:        PSEs for Effort
@@ -36,7 +36,7 @@ conflicts_prefer(dplyr::lag)
 here::i_am("Code/pre_sim/get_mrip_trips.R")
 source(here("Code", "helpers", "developer_setup.R"))
 
-output_folder<-file.path(gf.data.dir, "miscellaneous")
+output_folder<-file.path(sf.data.dir, "miscellaneous")
 
 vintage_string<-list.files(output_folder, pattern=glob2rx("mrip_pull*Rds"))
 vintage_string<-gsub("mrip_pull","",vintage_string)
@@ -63,48 +63,16 @@ list_names <- types %>%
   map_chr(~ paste(.x, collapse = "|"))
 
 
-# Sample code to get just Cod or Just Haddock
-# targets_COD <- types %>%
-#   map(~ mrip_effort(
-#     dom = c("YEAR", "WAVE"),
-#     microdata = mrip_pull,
-#     dir_trip = list(
-#       comname = c('ATLANTIC COD'),
-#       typ = .x
-#     )
-#   )) %>%
-#   set_names(list_names)
-#
-# targets_HADDOCK <- types %>%
-#   map(~ mrip_effort(
-#     dom = c("YEAR", "WAVE"),
-#     microdata = mrip_pull,
-#     dir_trip = list(
-#       comname = c('HADDOCK'),
-#       typ = .x
-#     )
-#   )) %>%
-#   set_names(list_names)
-
-# Target or caught Either
-
-groundfish_effort <- types %>%
+sfs_effort <- types %>%
   map(~ mrip_effort(
-    dom = c("YEAR", "WAVE","MODE1", "AREA_S"),
+    dom = c("YEAR", "WAVE","MODE1", "STOCK_REGION_CALC"),
     microdata = mrip_pull,
     dir_trip = list(
-      comname =  c('ATLANTIC COD', 'HADDOCK'),
+      comname =  c('SUMMER FLOUNDER', 'SCUP', 'BLACK SEA BASS'),
       typ = .x
     )
   )) %>%
   set_names(list_names)
 
 
-write_rds(groundfish_effort,file=file.path(output_folder, glue("groundfish_effort{data_vintage}.Rds")))
-
-
-# The relationship of some of the entries
-# PRIM1 : Cod + haddock=Either by definition
-# PRIM2: Same
-# Everything else: Either>= Cod, Either>=Haddock, Either<=Cod+Haddock
-
+write_rds(sfs_effort,file=file.path(output_folder, glue("sfs_effort{data_vintage}.Rds")))

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -122,7 +122,6 @@ set varabbrev on
 /* used by:
 tidyup_mrip_data_fromR.do*/
 
-global first_mrip_year 2023
 global last_mrip_year 2025
 numlist "$first_mrip_year/$last_mrip_year"
 
@@ -176,7 +175,6 @@ global fed_holidays_y2 "inlist(day_y2, td(01jan2026), td(19jan2026), td(16feb202
 global leap_yr_days "td(29feb2024)" 
 
 * Number of model iterations
-global ndraws 100
 
 * set years of which to pull the NEFSC trawl survey data
 global NEFSC_svy_yrs "inlist(year,2024, 2023, 2022)"

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -211,9 +211,9 @@ global seed 03211990
 
 // Control which modules to run (set to 0 to skip)
 loc pull_assessment = 1		 		// Pull Assessment data
+loc pull_MRIP= 1			 		// Pull MRIP data
 loc processMRIP = 1		 			// deal with casing MRIP data
 loc assemblemriplists = 1		 	// deal with casing MRIP data
-
 loc estimate_dtrips = 1				// Estimate Directed Trips 
 loc costs_per_trip = 1			// Create Distributions of costs per trip (run 1x)
 loc draw_angler_preferences = 1		// Create draw of angler preference parameters (run 1x)
@@ -276,11 +276,30 @@ if `push_NAA_to_gdrive' {
 	di "NAA pushed to GDrive"
 
 	}
+// 0) Pull MRIP data from Oracle (takes a while).
+
+/* Paths to the tidied MRIP extracts (written by tidyup_mrip_data_fromR.do). */
+	global catchlist "$misc_data_cd/mrip_catch.dta"	
+	global triplist  "$misc_data_cd/mrip_trip.dta"
+	global b2list  "$misc_data_cd/mrip_size_b2.dta"
+	global sizelist  "$misc_data_cd/mrip_size.dta"
+
+	
+	if `pull_MRIP' {
+  	di "Pulling MRIP data from oracle"
+		rscript using "$input_code_cd\get_mrip_oracle.R", args($first_mrip_year $last_mrip_year)
+    di "Oracle Data Pull Finished"
+
+  	di "Tidying up MRIP data"
+  	do "$input_code_cd\tidyup_mrip_data_fromR.do"
+  	di "Tidyup finished"
+
+}
 
 	
 	
 
-// 1) Pull the MRIP data
+// 1) Process MRIP data
 
 if `processMRIP' {
 	di "Processing MRIP data"
@@ -303,6 +322,10 @@ assert "${triplist}"!=""
 		// THIS NEEDS TO BE ADJUSTED EVERY YEAR. 
 
 if `estimate_dtrips' {
+  di "Compiling Aggregate Effort"
+		rscript using "$input_code_cd\get_mrip_trips.R"
+
+	di "Estimating Directed trips"
 
 	di "Estimating Directed trips"
     do "$input_code_cd\directed_trips_calibration.do"

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -60,7 +60,6 @@
                                 calibration_catch_per_trip_part2.do, which
                                 this toggle does not control.)
 
- PROTOTYPE MODE IS ON BY DEFAULT. `proto' = 1 overwrites $ndraws from 100 to
  3. Running this file exactly as committed therefore produces a 3-draw test
  run, not a production run. GroundfishRDM defaults the same toggle to 0. Set
  proto = 0 for a real run.

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -60,9 +60,6 @@
                                 calibration_catch_per_trip_part2.do, which
                                 this toggle does not control.)
 
- 3. Running this file exactly as committed therefore produces a 3-draw test
- run, not a production run. GroundfishRDM defaults the same toggle to 0. Set
- proto = 0 for a real run.
 *******************************************************************************/
 
 /**** SFSBSB RDM code wrapper ****/
@@ -122,6 +119,7 @@ set varabbrev on
 /* used by:
 tidyup_mrip_data_fromR.do*/
 
+global first_mrip_year 2022
 global last_mrip_year 2025
 numlist "$first_mrip_year/$last_mrip_year"
 
@@ -175,6 +173,7 @@ global fed_holidays_y2 "inlist(day_y2, td(01jan2026), td(19jan2026), td(16feb202
 global leap_yr_days "td(29feb2024)" 
 
 * Number of model iterations
+global ndraws 150
 
 * set years of which to pull the NEFSC trawl survey data
 global NEFSC_svy_yrs "inlist(year,2024, 2023, 2022)"

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -251,6 +251,7 @@ loc catch_per_trip_project=1       // Generate projection-year catch-per trip
 
 loc prep_NAA_for_dashboard = 1		// Pull Assessment data
 loc push_NAA_to_gdrive =1 			// Convert Assessment data to Rds, reshape to long, and push to googledrive
+loc run_calibration =0 				// Run calibration /sim/R wrapper.R
 
 
 /* Prototype mode will overrides
@@ -435,19 +436,20 @@ if `catch_per_trip_project'{
 		do "$input_code_cd\compare_projection_data_to_MRIP.do"
 }
 
-// 10) Run the projection loop in R
-
-/* Step 10 is a heading with no code beneath it. This is the wrapper-chaining
-   gap: GroundfishRDM's Stata wrapper calls its R wrapper here as a final
-   gated step, so the two halves cannot be run out of order. flukeRDM's
-   equivalent call was never written, which is why the pipeline has three
-   independent entry points that an operator must sequence by hand:
-       1. this file
-       2. Rscript "Code/sim/R code wrapper.R"
-       3. Rscript Run_Model.R <Run_Name>   (currently broken - see its header)
-   Closing this gap is in scope for the next flukeRDM development pass. */
-
 display "model_wrapper.do: Stata pre-simulation stage complete. NEXT STEP IS MANUAL - run Code/sim/'R code wrapper.R' to perform the R calibration; this wrapper does not call it."
+// 11) Run the calibration routine in R, export files to Google Drive
+
+/* not tested 8/25/2026*/
+
+if `run_calibration'{
+		di "Running calibration routine in R"
+	cd $here
+
+		rscript using "$here\Code\sim\R code wrapper.R", args($ndraws)
+    	di "Simulation model calibrated and files exported to Google Drive"
+
+		}
+
 
 
 if (`proto'==1) {

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -119,10 +119,23 @@ set varabbrev on
 
 * These need to be changed every year 
 
-* year-waves of MRIP data. 
-global yr_wvs 20221 20222 20223 20224 20225 20226 20231 20232 20233 20234 20235 20236  20241 20242 20243 20244 20245  20246 20251 20252 20253 20254 20255 20256
-global yearlist 2022 2023 2024 2025
+/* First and last year of MRIP data.*/
+/* used by:
+tidyup_mrip_data_fromR.do*/
+
+global first_mrip_year 2023
+global last_mrip_year 2025
+numlist "$first_mrip_year/$last_mrip_year"
+
+global yearlist  `r(numlist)'
 global wavelist 1 2 3 4 5 6
+
+
+* year-waves of MRIP data. 
+global yr_wvs 20221 20222 20223 20224 20225 20226  ///
+			  20231 20232 20233 20234 20235 20236  ///
+			  20241 20242 20243 20244 20245 20246  ///
+			  20251 20252 20253 20254 20255 20256
 
 global calibration_year "(year==2024 & inlist(wave, 1, 2, 3, 4, 5, 6))"
 global calibration_year_num 2024
@@ -212,8 +225,8 @@ global seed 03211990
 // Control which modules to run (set to 0 to skip)
 loc pull_assessment = 1		 		// Pull Assessment data
 loc pull_MRIP= 1			 		// Pull MRIP data
-loc processMRIP = 1		 			// deal with casing MRIP data
-loc assemblemriplists = 1		 	// deal with casing MRIP data
+loc processMRIP = 0		 			// deal with casing MRIP data
+loc assemblemriplists = 0		 	// deal with casing MRIP data
 loc estimate_dtrips = 1				// Estimate Directed Trips 
 loc costs_per_trip = 1			// Create Distributions of costs per trip (run 1x)
 loc draw_angler_preferences = 1		// Create draw of angler preference parameters (run 1x)
@@ -240,7 +253,7 @@ loc prep_NAA_for_dashboard = 1		// Pull Assessment data
 loc push_NAA_to_gdrive =1 			// Convert Assessment data to Rds, reshape to long, and push to googledrive
 
 
-/* Prototype mode. ON as committed - see the header. This silently overrides
+/* Prototype mode will overrides
    the $ndraws 100 set above with 3, which makes a full pass through the
    pipeline finish in a fraction of the time but produces results too noisy to
    use. Note also that the R side does not read $ndraws at all: "R code wrapper.R"

--- a/Code/pre_sim/tidyup_mrip_data_fromR.do
+++ b/Code/pre_sim/tidyup_mrip_data_fromR.do
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ Script:       tidyup_mrip_data_fromR.do
+ Purpose:      Cleans the MRIP trip/catch/size/size_b2 files freshly pulled from
+               Oracle via R's tacklebox: enforces column types, converts the
+               pull-date string to a Stata date, and filters each file to the
+               year-wave combinations listed in $yr_wvs.
+ Inputs:       The .dta files named in globals $catchlist $triplist $b2list
+               $sizelist (the raw MRIP extracts written by get_mrip_oracle.R).
+ Outputs:      The same files, overwritten in place, with:
+                 - strat_id psu_id id_code zip forced to string
+                 - year wave st forced to numeric
+                 - mrip_pull_date converted to a Stata %td date
+                 - rows restricted to the year-wave patterns in $yr_wvs
+ Dependencies: Globals $catchlist/$triplist/$b2list/$sizelist and $yr_wvs
+               (set in model_wrapper.do). Runs immediately after
+               get_mrip_oracle.R.
+ Pipeline:     Step 2 of model_wrapper.do, gated by `pull_MRIP' (default ON),
+               directly following the get_mrip_oracle.R Oracle pull.
+			   
+ Note:			Exact copy of same file in groundfishRDM repository
+*******************************************************************************/
+
+display "Tidying MRIP catch/trip/size files (type enforcement + year-wave filter) ..."
+
+foreach l in $catchlist $triplist $b2list $sizelist {
+
+	use `l', clear
+	/* enforce certain variables as strings */
+	foreach var of varlist strat_id psu_id id_code zip{
+		cap tostring `var', replace
+	}
+	/* enforce other variables as numeric */
+	foreach var of varlist year wave st{
+		destring `var', replace
+	}
+
+	/* filter based on the global yr_wvs */
+	
+	gen yr_wave=year*10+wave	
+	gen yrwave_keep=0
+	qui foreach l of global yr_wvs{
+		replace yrwave_keep=1 if yr_wave==`l'
+	}
+	keep if yrwave_keep==1
+	drop yrwave_keep yr_wave
+	
+save `l', replace
+}
+
+display "Finished tidying MRIP files."

--- a/Code/sim/R code wrapper.R
+++ b/Code/sim/R code wrapper.R
@@ -153,11 +153,22 @@ iterative_input_data_cd="E:/Lou_projects/flukeRDM/flukeRDM_iterative_data"
 #options("RStata.StataPath" = "\"C:\\Program Files\\Stata17\\StataMP-64\"")
 #options("RStata.StataVersion" = 17)
 
-# The comment below describes the intended design (125 calibration draws, 100
-# used); the value actually set is 10, i.e. this file is currently configured
-# for a test run, not production. Nothing links this to Stata's $ndraws.
-#Set number of original draws. We create 125 (in case some don't converge in the calibration), but only use 100 for the final run. Choose a lot fewer for test runs
-n_simulations<-10
+#Read in number of original draws.
+
+# Number of model iterations. Match Stata's $ndraws
+# (model_wrapper.do) using the argument in Stata call
+# Define arguments
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1) {
+  stop("Error: This script requires exactly one argument.", call. = FALSE)
+}
+n_simulations  <- as.numeric(args[1]) # Number of model iterations.
+
+# Show them, just in case.
+cat("Number of model iterations selected:", n_simulations, "\n")
+
+
+
 
 # n_draws is not referenced anywhere in this file or the scripts it sources.
 n_draws<-50 #Number of simulated trips per day


### PR DESCRIPTION
Brings the MRIP data pull and 1st level of processing in from groundfishRDM

Also as adds this to the toggled execution chain

```
if `run_calibration'{
		di "Running calibration routine in R"
	cd $here

		rscript using "$here\Code\sim\R code wrapper.R", args($ndraws)
    	di "Simulation model calibrated and files exported to Google Drive"

		} 
```

@acarrharris this is essentially carrying over things from groundfishRDM

The R data pull from oracle also takes care of variable casing 
https://github.com/kimberly-bastille/flukeRDM/blob/eef6793e65e86934212236cd6580380144f85712/Code/pre_sim/get_mrip_oracle.R#L145-L146

And the dataset listing is not longer needed.